### PR TITLE
Bugfix: Remove trailing decimal separator if pattern has trailing code/symbol

### DIFF
--- a/lib/src/pattern_encoder.dart
+++ b/lib/src/pattern_encoder.dart
@@ -52,7 +52,12 @@ class PatternEncoder implements MoneyEncoder<String> {
 
       /// ensure we don't end up with a trailing decimal point.
       if (formattedMinorPart.isNotEmpty) {
-        formatted += data.currency.decimalSeparator + formattedMinorPart;
+        final numericMinorPart =
+            formattedMinorPart.replaceAll(RegExp('[^0-9]'), '');
+        final decimalSeparator =
+            numericMinorPart.isNotEmpty ? data.currency.decimalSeparator : '';
+
+        formatted += decimalSeparator + formattedMinorPart;
       }
     }
 

--- a/test/src/money_format_test.dart
+++ b/test/src/money_format_test.dart
@@ -78,6 +78,15 @@ void main() {
           Money.fromInt(301, code: 'USD').format('000.000'), equals('003.010'));
     });
 
+    test('trailing zero when pattern have trailing symbol', () {
+      final usdt = Currency.create('USDT', 2, pattern: '#,##0.## CCC');
+      expect(Money.fromIntWithCurrency(01, usdt).toString(), '0.01 USDT');
+      expect(Money.fromIntWithCurrency(301, usdt).toString(), '3.01 USDT');
+      expect(Money.fromIntWithCurrency(3010, usdt).toString(), '30.1 USDT');
+      expect(Money.fromIntWithCurrency(100, usdt).toString(), '1 USDT');
+      expect(Money.fromIntWithCurrency(1000, usdt).toString(), '10 USDT');
+    });
+
     test('less than 10 cents USD in minor units', () {
       expect(Money.fromInt(01, code: 'USD').toString(), r'$0.01');
       expect(Money.fromInt(301, code: 'USD').toString(), r'$3.01');


### PR DESCRIPTION
This will fix trailing decimal separator when a money has no decimal value but its currency's pattern has symbol/code on the end.

Steps to reproduce:
1. Create a currency which pattern has a symbol/code on the end. (e.g. **"#,##0.## CCC"**)
`final usdt = Currency.create('USDT', 2, pattern: '#,##0.## CCC');`
2. Create a money from the above currency that has no decimal value 
`final usdtBalance = Money.fromIntWithCurrency(100, usdt);`
3. Convert money to string
`print(usdtBalance.toString());`

Print Result
- Before Fix (decimal separator is shown)
`1. USDT`
- After Fix (decimal separator is not shown)
`1 USDT`
