### PR TITLE
Operator == in Money returns false on incompatible type

### DIFF
--- a/lib/src/money.dart
+++ b/lib/src/money.dart
@@ -536,9 +536,9 @@ class Money implements Comparable<Money> {
   /// Returns `true` if [other] is the same amount of money in
   /// the same currency.
   @override
-  bool operator ==(covariant Money other) =>
+  bool operator ==(Object other) =>
       identical(this, other) ||
-      (isInSameCurrencyAs(other) && other.amount == amount);
+      (other is Money && isInSameCurrencyAs(other) && other.amount == amount);
 
   /// Returns `true` when this money is less than [other].
   ///


### PR DESCRIPTION
Let's avoid throwing an exception when comparing Money to another type. Such a comparison can happen in code auto-generated by dart_mappable or freezed.

Resolves #85 